### PR TITLE
Update Tyruswoo_ScreenshotSnapper.js plugindesc to include "MZ"

### DIFF
--- a/Tyruswoo_ScreenshotSnapper.js
+++ b/Tyruswoo_ScreenshotSnapper.js
@@ -36,8 +36,8 @@ Tyruswoo.ScreenshotSnapper = Tyruswoo.ScreenshotSnapper || {};
 
 /*:
  * @target MZ
- * @plugindesc v1.0.1 Snap screenshots and save them to a folder! Great for showcasing your
- *             project, and players can save screenshots of favorite moments during gameplay!
+ * @plugindesc MZ v1.0.1 Snap screenshots and save them to a folder! Great for showcasing your
+ *             project, and players can save screenshots of gameplay!
  * @author Tyruswoo
  * @url https://www.tyruswoo.com
  *


### PR DESCRIPTION
plugindesc text "MZ" now indicates target RPG Maker edition, viewable from the plugin manager.